### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint, Pytest and Build
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hofiorg/python_scripts/security/code-scanning/1](https://github.com/hofiorg/python_scripts/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient for most steps, and no write permissions are needed. This change will ensure that the workflow operates securely with the least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
